### PR TITLE
sandcastle: uv-Cache im Image vorwärmen gegen uv-sync-Timeout

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -51,6 +51,18 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # sandboxes, so `uv sync` finds it ready and only needs to link the .venv.
 RUN uv python install 3.14
 
+# Warm uv's cache with the project's locked dependencies. The per-sandbox
+# `uv sync` hook in main.mts otherwise re-downloads every wheel (notably
+# litellm's large transitive tree) on each container start, which overruns the
+# 60s hook timeout. The workspace is bind-mounted at runtime, so a .venv built
+# here would be shadowed — but the uv cache (~/.local/share/uv) survives, so the
+# runtime `uv sync` installs from cache (offline, fast) instead of downloading.
+# Rebuild the image (sandcastle docker build-image) after changing uv.lock.
+COPY --chown=agent:agent pyproject.toml uv.lock /home/agent/prime/
+RUN cd /home/agent/prime \
+  && uv sync --frozen \
+  && rm -rf /home/agent/prime
+
 # In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
 # and overrides the working directory to /home/agent/workspace at container start.
 # Structure your Dockerfile so that /home/agent/workspace can serve as the project root.

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -59,15 +59,20 @@ const codexSandbox = () =>
   });
 
 // Hooks run inside the sandbox before the agent starts. uv sync ensures fresh
-// dependencies; the managed Python 3.14 toolchain is pre-provisioned in the
-// image (see .sandcastle/Dockerfile), so sync only links the .venv instead of
-// re-downloading the interpreter. The second command copies the Codex auth
+// dependencies; both the managed Python 3.14 toolchain and the project's locked
+// wheels are pre-provisioned in the image (see .sandcastle/Dockerfile), so sync
+// installs from uv's warm cache and only links the .venv instead of downloading
+// the interpreter and dependencies. The second command copies the Codex auth
 // material from the read-only mount into CODEX_HOME so the Codex CLI is
 // authenticated.
 const hooks = {
   sandbox: {
     onSandboxReady: [
-      { command: "uv sync" },
+      // The image (see .sandcastle/Dockerfile) pre-warms uv's cache, so this
+      // normally installs from cache in seconds. The raised timeout is a safety
+      // net for a cold cache (first run after a uv.lock change / image rebuild),
+      // where wheels are still downloaded.
+      { command: "uv sync", timeoutMs: 120_000 },
       {
         command: [
           `mkdir -p "${sandboxCodexHome}"`,


### PR DESCRIPTION
## Problem

`npx tsx .sandcastle/main.mts` bricht mit `HookTimeoutError: Hook 'uv sync' timed out after 60000ms` ab. Das Image (`.sandcastle/Dockerfile`) provisioniert zwar den Python-3.14-Interpreter vor, aber **nicht die Dependencies**. Deshalb lädt der `onSandboxReady`-Hook `uv sync` bei jedem Sandbox-Start sämtliche Wheels neu — `litellm==1.80.10` zieht einen grossen transitiven Baum — und reisst den 60-s-Default-Timeout.

## Änderungen

- **Dockerfile:** `pyproject.toml` + `uv.lock` ins Image kopieren und beim Build `uv sync --frozen` ausführen, um uvs Cache (`~/.local/share/uv`) zu füllen. Der Cache überlebt den Workspace-Bind-Mount, sodass der Laufzeit-`uv sync` offline aus dem Cache installiert (Sekunden statt Download). Nach `uv.lock`-Änderungen Image neu bauen (`sandcastle docker build-image`).
- **main.mts:** Hook-Timeout auf `120_000` ms als Sicherheitsnetz für einen kalten Cache (erster Lauf nach Lock-Änderung / Image-Rebuild).

## Verifikation

- `npx tsx --check .sandcastle/main.mts` → exit 0
- `uv lock --check` → Lock konsistent mit `pyproject.toml`, d. h. `uv sync --frozen` schlägt im Build nicht fehl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)