### PR TITLE
Prototyp #98: Zuordnungs-UI der Fragebogen-Items (Wegwerfcode)

### DIFF
--- a/erhebungen/prototyp_98.py
+++ b/erhebungen/prototyp_98.py
@@ -1,0 +1,61 @@
+"""PROTOTYP zu Issue #98 — WEGWERFCODE, nicht produktiv nutzen.
+
+Frage: Wie stellt eine Forschende aus der Item-Bibliothek die Batterie ihrer
+Erhebung zusammen? Drei Varianten der Zuordnungs-UI, umschaltbar über
+`?variant=A|B|C` auf der bestehenden Erhebungs-Detailseite.
+
+Die App `fragebogen_items` existiert noch nicht (Spec #97 baut sie erst), also
+liefert dieses Modul Stub-Daten. Nichts hier wird persistiert; alle Aktionen
+laufen clientseitig in Alpine. Nach der Entscheidung: Datei löschen.
+"""
+
+from typing import Any
+
+_BIBLIOTHEK: list[dict[str, Any]] = [
+    {"pk": 1, "text": "Wie sicher fühlten Sie sich bei Ihrer Diagnose?", "typ": "likert"},
+    {"pk": 2, "text": "Was hat Sie an der Reaktion der Schülerin überrascht?", "typ": "freitext"},
+    {"pk": 3, "text": "Die Vignette wirkte auf mich realistisch.", "typ": "likert"},
+    {"pk": 4, "text": "Ich konnte den zugrunde liegenden Denkfehler klar benennen.", "typ": "likert"},
+    {"pk": 5, "text": "Welche weiteren Informationen hätten Sie gebraucht?", "typ": "freitext"},
+    {"pk": 6, "text": "In welchem Fachsemester studieren Sie?", "typ": "freitext"},
+    {"pk": 7, "text": "Ich habe bereits eigenständig unterrichtet.", "typ": "likert"},
+    {"pk": 8, "text": "Die Bedienung der Oberfläche fiel mir leicht.", "typ": "likert"},
+    {"pk": 9, "text": "Anmerkungen zur Studie", "typ": "freitext"},
+    {"pk": 10, "text": "Ich würde solche Vignetten im Studium weiterempfehlen.", "typ": "likert"},
+]
+
+_ZUORDNUNG: list[dict[str, Any]] = [
+    {"pk": 1, "andockpunkt": "nach_sitzung", "position": 1},
+    {"pk": 3, "andockpunkt": "nach_sitzung", "position": 2},
+    {"pk": 4, "andockpunkt": "nach_sitzung", "position": 3},
+    {"pk": 6, "andockpunkt": "am_ende", "position": 1},
+    {"pk": 7, "andockpunkt": "am_ende", "position": 2},
+    {"pk": 9, "andockpunkt": "am_ende", "position": 3},
+]
+
+VARIANTEN: dict[str, str] = {
+    "A": "Zwei Andockpunkt-Bereiche",
+    "B": "Eine Bibliothek, zwei Körbe",
+    "C": "Eine Zuordnungstabelle",
+}
+
+
+def kontext(variante: str | None) -> dict[str, Any]:
+    """Baut den Prototyp-Kontext; ohne gültige Variante bleibt der Prototyp aus."""
+
+    if variante not in VARIANTEN:
+        return {}
+    zugeordnet: list[dict[str, Any]] = [
+        {**next(item for item in _BIBLIOTHEK if item["pk"] == eintrag["pk"]), **eintrag}
+        for eintrag in _ZUORDNUNG
+    ]
+    zugeordnete_pks: set[int] = {eintrag["pk"] for eintrag in _ZUORDNUNG}
+    return {
+        "prototyp_variante": variante,
+        "prototyp_variantenname": VARIANTEN[variante],
+        "prototyp_varianten": list(VARIANTEN),
+        "prototyp_bibliothek": [
+            item for item in _BIBLIOTHEK if item["pk"] not in zugeordnete_pks
+        ],
+        "prototyp_zugeordnet": zugeordnet,
+    }

--- a/erhebungen/templates/erhebungen/anlegen.html
+++ b/erhebungen/templates/erhebungen/anlegen.html
@@ -1,25 +1,38 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}Erhebung anlegen{% endblock %}
 
+{% block extra_head %}
+    <link rel="stylesheet" href="{% static 'css/vignette-form.css' %}">
+{% endblock %}
+
 {% block content %}
-    <div class="page area--research">
-        <header class="area-band"><h1>Erhebung anlegen</h1></header>
-        <section class="page-section">
-            <div class="page-section__head">
-                <b>01</b>
-                <div>
-                    <h2>Name</h2>
-                </div>
-            </div>
-            <form method="post">
-                {% csrf_token %}
-                <p>
+<section class="page area--research">
+    <header class="page-head">
+        <div>
+            <p>Forschung</p>
+            <h1>Neue Erhebung anlegen</h1>
+            <span>Legen Sie den Namen für die Datenerhebung fest.</span>
+        </div>
+    </header>
+    <form method="post">
+        {% csrf_token %}
+        <section class="page-section" aria-labelledby="section-name">
+            <header class="page-section__head">
+                <b>01</b><span><h2 id="section-name">Name</h2><small>Wie soll die Erhebung heißen?</small></span>
+            </header>
+            <div class="field-grid">
+                <div class="vignette-field">
                     <label for="id_name">Name</label>
                     <input id="id_name" name="name" required>
-                </p>
-                <button type="submit">Anlegen</button>
-            </form>
+                </div>
+            </div>
         </section>
-    </div>
+        <div class="vignette-form-actions">
+            <a href="{% url 'erhebungen:liste' %}">Abbrechen</a>
+            <button class="button" type="submit">Anlegen</button>
+        </div>
+    </form>
+</section>
 {% endblock %}

--- a/erhebungen/templates/erhebungen/detail.html
+++ b/erhebungen/templates/erhebungen/detail.html
@@ -1,46 +1,146 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}{{ erhebung.name }}{% endblock %}
 
+{% block extra_head %}
+    <link rel="stylesheet" href="{% static 'css/vignette-form.css' %}">
+    <link rel="stylesheet" href="{% static 'css/vignette-pages.css' %}">
+{% endblock %}
+
 {% block content %}
-    <div class="page area--research">
-        <header class="area-band"><h1>{{ erhebung.name }}</h1></header>
-        <section class="page-section">
-            <div class="page-section__head">
-                <b>01</b>
-                <div>
-                    <h2>Entwurf</h2>
-                    <small>{{ erhebung.get_status_display }}</small>
-                </div>
-            </div>
-            {% if erhebung.status == erhebung.Status.ENTWURF %}
-                <form method="post" action="{% url 'erhebungen:konfiguration_speichern' erhebung.pk %}">
+<section class="page">
+    <header class="page-head">
+        <div>
+            <p>Forschung / Meine Erhebungen</p>
+            <h1>{{ erhebung.name }}</h1>
+        </div>
+        <span class="badge badge--{{ erhebung.status|lower }}">{{ erhebung.get_status_display }}</span>
+    </header>
+
+    <div class="vignette-detail-actions">
+        {% if erhebung.status == erhebung.Status.ENTWURF %}
+            <form method="post" action="{% url 'erhebungen:finalisieren' erhebung.pk %}">
+                {% csrf_token %}
+                <button class="button" type="submit">Finalisieren</button>
+            </form>
+        {% else %}
+            {% if kann_zurueckziehen %}
+                <form method="post" action="{% url 'erhebungen:zurueckziehen' erhebung.pk %}">
                     {% csrf_token %}
-                    <p>
-                        <label for="id_randomisierung">Reihenfolge</label>
-                        <select id="id_randomisierung" name="randomisierung">
-                            {% for wert, bezeichnung in erhebung.Randomisierung.choices %}
-                                <option value="{{ wert }}"{% if wert == erhebung.randomisierung %} selected{% endif %}>{{ bezeichnung }}</option>
-                            {% endfor %}
-                        </select>
-                    </p>
-                    <p>
+                    <button class="button button--secondary" type="submit">Zurückziehen</button>
+                </form>
+            {% endif %}
+            {% if kann_archivieren %}
+                <form method="post" action="{% url 'erhebungen:archivieren' erhebung.pk %}">
+                    {% csrf_token %}
+                    <button class="button button--danger" type="submit">Erhebung archivieren</button>
+                </form>
+            {% elif kann_entarchivieren %}
+                <form method="post" action="{% url 'erhebungen:entarchivieren' erhebung.pk %}">
+                    {% csrf_token %}
+                    <button class="button" type="submit">Erhebung entarchivieren</button>
+                </form>
+            {% endif %}
+        {% endif %}
+    </div>
+
+    {% if erhebung.status == erhebung.Status.ENTWURF %}
+        <div id="erhebung-entwurf-editor" x-data="{
+                randomisierung: '{{ erhebung.randomisierung }}',
+                aufgenommeneRows: JSON.parse(document.getElementById('aufgenommene-daten').textContent),
+                verfuegbareRows: JSON.parse(document.getElementById('verfuegbare-daten').textContent),
+                qAufg: '', sortKeyAufg: 'label', sortDirAufg: 1,
+                qVerf: '', sortKeyVerf: 'label', sortDirVerf: 1,
+
+                get sichtbarAufg() {
+                    const q = this.qAufg.trim().toLowerCase();
+                    return this.aufgenommeneRows
+                        .filter(r => !q || [r.label, r.fach, r.thema].join(' ').toLowerCase().includes(q))
+                        .sort((a, b) => {
+                            const x = (a[this.sortKeyAufg] ?? '').toString().toLowerCase();
+                            const y = (b[this.sortKeyAufg] ?? '').toString().toLowerCase();
+                            return x.localeCompare(y, 'de', { numeric: true }) * this.sortDirAufg;
+                        });
+                },
+                get sichtbarVerf() {
+                    const q = this.qVerf.trim().toLowerCase();
+                    return this.verfuegbareRows
+                        .filter(r => !q || [r.label, r.fach, r.thema].join(' ').toLowerCase().includes(q))
+                        .sort((a, b) => {
+                            const x = (a[this.sortKeyVerf] ?? '').toString().toLowerCase();
+                            const y = (b[this.sortKeyVerf] ?? '').toString().toLowerCase();
+                            return x.localeCompare(y, 'de', { numeric: true }) * this.sortDirVerf;
+                        });
+                },
+                sortiereAufg(key) { if (this.sortKeyAufg === key) this.sortDirAufg *= -1; else { this.sortKeyAufg = key; this.sortDirAufg = 1; } },
+                sortiereVerf(key) { if (this.sortKeyVerf === key) this.sortDirVerf *= -1; else { this.sortKeyVerf = key; this.sortDirVerf = 1; } },
+                pfeilKlasseAufg(key) { return this.sortKeyAufg !== key ? '' : (this.sortDirAufg === 1 ? 'table__sort-arrow--auf' : 'table__sort-arrow--ab'); },
+                pfeilKlasseVerf(key) { return this.sortKeyVerf !== key ? '' : (this.sortDirVerf === 1 ? 'table__sort-arrow--auf' : 'table__sort-arrow--ab'); },
+
+                async toggleVignette(url) {
+                    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+                    const formData = new FormData();
+                    formData.append('csrfmiddlewaretoken', csrfToken);
+                    const response = await fetch(url, { method: 'POST', body: formData });
+                    const html = await response.text();
+                    
+                    const doc = new DOMParser().parseFromString(html, 'text/html');
+                    this.aufgenommeneRows = JSON.parse(doc.getElementById('aufgenommene-daten').textContent);
+                    this.verfuegbareRows = JSON.parse(doc.getElementById('verfuegbare-daten').textContent);
+                    
+                    const newPositions = doc.getElementById('vignetten-positionen-inhalt');
+                    const currentPositions = document.getElementById('vignetten-positionen-inhalt');
+                    if (newPositions && currentPositions) {
+                        currentPositions.innerHTML = newPositions.innerHTML;
+                    }
+                }
+            }"
+        >
+        {{ aufgenommene_daten|json_script:"aufgenommene-daten" }}
+        {{ verfuegbare_daten|json_script:"verfuegbare-daten" }}
+
+        <form method="post" action="{% url 'erhebungen:konfiguration_speichern' erhebung.pk %}">
+            {% csrf_token %}
+            <section class="page-section" aria-labelledby="section-config">
+                <header class="page-section__head">
+                    <b>01</b><span><h2 id="section-config">Konfiguration</h2><small>Instruktion, Einwilligung und Abschluss definieren.</small></span>
+                </header>
+                <div class="field-grid">
+                    <div class="vignette-field page-field--wide">
                         <label for="id_instruktionstext">Instruktion</label>
                         <textarea id="id_instruktionstext" name="instruktionstext">{{ erhebung.instruktionstext }}</textarea>
-                    </p>
-                    <p>
+                    </div>
+                    <div class="vignette-field page-field--wide">
                         <label for="id_einwilligungstext">Einwilligung</label>
                         <textarea id="id_einwilligungstext" name="einwilligungstext">{{ erhebung.einwilligungstext }}</textarea>
-                    </p>
-                    <p>
+                    </div>
+                    <div class="vignette-field page-field--wide">
                         <label for="id_abschlusstext">Abschluss</label>
                         <textarea id="id_abschlusstext" name="abschlusstext">{{ erhebung.abschlusstext }}</textarea>
-                    </p>
-                    {% if erhebung.randomisierung == erhebung.Randomisierung.FEST %}
-                        <p>Reihenfolge der aufgenommenen Vignetten:</p>
-                        <ol>
+                    </div>
+                </div>
+            </section>
+
+            <section class="page-section" aria-labelledby="section-order">
+                <header class="page-section__head">
+                    <b>02</b><span><h2 id="section-order">Reihenfolge</h2><small>Präsentationsreihenfolge der Vignetten konfigurieren.</small></span>
+                </header>
+                <div class="field-grid">
+                    <div class="vignette-field page-field--wide">
+                        <label for="id_randomisierung">Modus der Reihenfolge</label>
+                        <select id="id_randomisierung" name="randomisierung" x-model="randomisierung">
+                            {% for wert, bezeichnung in erhebung.Randomisierung.choices %}
+                                <option value="{{ wert }}">{{ bezeichnung }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+
+                    <div id="vignetten-positionen" class="vignette-field page-field--wide" x-show="randomisierung === '{{ erhebung.Randomisierung.FEST }}'" x-cloak>
+                        <p style="margin-bottom: 1rem;"><strong>Positionen (feste Reihenfolge)</strong></p>
+                        <div id="vignetten-positionen-inhalt" class="field-grid">
                             {% for zugehoerigkeit in vignettenzugehoerigkeiten %}
-                                <li>
+                                <div class="vignette-field page-field--wide">
                                     <label for="id_vignette_{{ forloop.counter }}">Position {{ forloop.counter }}</label>
                                     <select id="id_vignette_{{ forloop.counter }}" name="vignetten">
                                         {% for option in vignettenzugehoerigkeiten %}
@@ -49,133 +149,170 @@
                                             </option>
                                         {% endfor %}
                                     </select>
-                                </li>
+                                </div>
                             {% endfor %}
-                        </ol>
-                    {% endif %}
-                    <button type="submit">Konfiguration speichern</button>
-                </form>
-                <h2>Vignetten</h2>
-                <ul>
-                    {% for zugehoerigkeit in vignettenzugehoerigkeiten %}
-                        <li>
-                            {{ zugehoerigkeit.vignette.historie.name|default:zugehoerigkeit.vignette.fach }}
-                            <form method="post" action="{% url 'erhebungen:vignette_entfernen' erhebung.pk zugehoerigkeit.vignette.pk %}">
-                                {% csrf_token %}
-                                <button type="submit">Entfernen</button>
-                            </form>
-                        </li>
-                    {% empty %}
-                        <li>Noch keine Vignetten aufgenommen.</li>
-                    {% endfor %}
-                </ul>
-                <h2>Finale Vignetten aufnehmen</h2>
-                <ul>
-                    {% for vignette in verfuegbare_vignetten %}
-                        <li>
-                            {{ vignette.historie.name|default:vignette.fach }}
-                            <form method="post" action="{% url 'erhebungen:vignette_hinzufuegen' erhebung.pk vignette.pk %}">
-                                {% csrf_token %}
-                                <button type="submit">Aufnehmen</button>
-                            </form>
-                        </li>
-                    {% empty %}
-                    <li>Keine weiteren finalen Vignetten verfügbar.</li>
-                    {% endfor %}
-                </ul>
-                <form method="post" action="{% url 'erhebungen:finalisieren' erhebung.pk %}">
-                    {% csrf_token %}
-                    <button type="submit">Finalisieren</button>
-                </form>
-            {% else %}
-                <p>Das finale Design ist gesperrt.</p>
-                <h2>Gepinnte Modell-Konfiguration</h2>
-                <dl>
-                    <div><dt>Sprachmodell</dt><dd>{{ erhebung.modell_konfiguration.sprachmodell }}</dd></div>
-                    <div><dt>Parameter</dt><dd>{{ erhebung.modell_konfiguration.parameter }}</dd></div>
-                </dl>
-                {% if kann_zurueckziehen %}
-                    <form method="post" action="{% url 'erhebungen:zurueckziehen' erhebung.pk %}">
-                        {% csrf_token %}
-                        <button type="submit">Zurückziehen</button>
-                    </form>
-                {% endif %}
-                {% if kann_archivieren %}
-                    <form method="post" action="{% url 'erhebungen:archivieren' erhebung.pk %}">
-                        {% csrf_token %}
-                        <button type="submit">Erhebung archivieren</button>
-                    </form>
-                {% elif kann_entarchivieren %}
-                    <form method="post" action="{% url 'erhebungen:entarchivieren' erhebung.pk %}">
-                        {% csrf_token %}
-                        <button type="submit">Erhebung entarchivieren</button>
-                    </form>
-                {% endif %}
-            {% endif %}
-            {% if erhebung.status == erhebung.Status.FINAL %}
-                <h2>Stichproben</h2>
-                <form method="post" action="{% url 'erhebungen:stichprobe_anlegen' erhebung.pk %}">
-                    {% csrf_token %}
-                    <p>
-                        <label for="id_beginn">Beginn</label>
-                        <input
-                            id="id_beginn"
-                            type="datetime-local"
-                            name="beginn"
-                            required
-                        >
-                    </p>
-                    <p>
-                        <label for="id_ende">Ende</label>
-                        <input
-                            id="id_ende"
-                            type="datetime-local"
-                            name="ende"
-                            required
-                        >
-                    </p>
-                    <button type="submit">Stichprobe anlegen</button>
-                </form>
-                <ul>
-                    {% for stichprobe in stichproben %}
-                        <li>
-                            <dl>
-                                <div>
-                                    <dt>Zeitraum</dt>
-                                    <dd>{{ stichprobe.beginn }} – {{ stichprobe.ende }}</dd>
-                                </div>
-                                <div>
-                                    <dt>Phase</dt>
-                                    <dd>{{ stichprobe.phase }}</dd>
-                                </div>
-                                <div>
-                                    <dt>Teilnahmen</dt>
-                                    <dd>{{ stichprobe.teilnahmezahl }}</dd>
-                                </div>
-                                <div>
-                                    <dt>Teilnahme-Link</dt>
-                                    <dd>
-                                        <input
-                                            type="text"
-                                            value="{{ stichprobe.teilnahme_url }}"
-                                            readonly
-                                        >
-                                    </dd>
-                                </div>
-                            </dl>
-                            {% if not stichprobe.archiviert and not stichprobe.traegt_daten %}
-                                <form method="post" action="{% url 'erhebungen:stichprobe_archivieren' erhebung.pk stichprobe.pk %}">
-                                    {% csrf_token %}
-                                    <button type="submit">Stichprobe archivieren</button>
-                                </form>
+                            {% if not vignettenzugehoerigkeiten %}
+                                <p>Noch keine Vignetten aufgenommen.</p>
                             {% endif %}
-                        </li>
-                    {% empty %}
-                        <li>Noch keine Stichproben angelegt.</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            <p><a href="{% url 'erhebungen:liste' %}">Zu meinen Erhebungen</a></p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <div class="vignette-form-actions">
+                <button class="button" type="submit">Konfiguration speichern</button>
+            </div>
+        </form>
+
+        <section class="page-section" aria-labelledby="section-vignettes">
+            <header class="page-section__head">
+                <b>03</b><span><h2 id="section-vignettes">Vignetten verwalten</h2><small>Fügen Sie der Erhebung finale Vignetten hinzu oder entfernen Sie diese.</small></span>
+            </header>
+            <div class="field-grid page-field--wide" style="grid-template-columns: 1fr 1fr; align-items: start;">
+                
+                <!-- Verfügbare Vignetten Table (LEFT) -->
+                <div class="vignette-field">
+                    <p><strong>Finale Vignetten aufnehmen</strong></p>
+                    <div class="table-toolbar">
+                        <input type="search" class="table-toolbar__search" placeholder="Suchen…" aria-label="Verfügbare Vignetten durchsuchen" x-model="qVerf">
+                        <span class="table-toolbar__count" x-text="sichtbarVerf.length + ' von ' + verfuegbareRows.length"></span>
+                    </div>
+                    <div class="table-wrap vignette-index-table">
+                        <table class="table table--sortable">
+                            <thead>
+                                <tr>
+                                    <th scope="col"><button type="button" class="table__sort" @click="sortiereVerf('label')">Name<span class="table__sort-arrow" :class="pfeilKlasseVerf('label')"></span></button></th>
+                                    <th scope="col">Aktion</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <template x-for="r in sichtbarVerf" :key="r.pk">
+                                    <tr>
+                                        <td x-text="r.label"></td>
+                                        <td>
+                                            <button class="button button--secondary button--small" type="button" @click="toggleVignette(r.aufnehmen_url)">Aufnehmen</button>
+                                        </td>
+                                    </tr>
+                                </template>
+                                <tr x-show="sichtbarVerf.length === 0">
+                                    <td colspan="2" class="table__empty">Keine weiteren finalen Vignetten verfügbar.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <!-- Aufgenommene Vignetten Table (RIGHT) -->
+                <div class="vignette-field">
+                    <p><strong>Aufgenommene Vignetten</strong></p>
+                    <div class="table-toolbar">
+                        <input type="search" class="table-toolbar__search" placeholder="Suchen…" aria-label="Aufgenommene Vignetten durchsuchen" x-model="qAufg">
+                        <span class="table-toolbar__count" x-text="sichtbarAufg.length + ' von ' + aufgenommeneRows.length"></span>
+                    </div>
+                    <div class="table-wrap vignette-index-table">
+                        <table class="table table--sortable">
+                            <thead>
+                                <tr>
+                                    <th scope="col"><button type="button" class="table__sort" @click="sortiereAufg('label')">Name<span class="table__sort-arrow" :class="pfeilKlasseAufg('label')"></span></button></th>
+                                    <th scope="col">Aktion</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <template x-for="r in sichtbarAufg" :key="r.pk">
+                                    <tr>
+                                        <td x-text="r.label"></td>
+                                        <td>
+                                            <button class="button button--danger button--small" type="button" @click="toggleVignette(r.entfernen_url)">Entfernen</button>
+                                        </td>
+                                    </tr>
+                                </template>
+                                <tr x-show="sichtbarAufg.length === 0">
+                                    <td colspan="2" class="table__empty">Keine Vignetten gefunden.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
         </section>
+        </div>
+
+
+    {% else %}
+        <section class="page-section" aria-labelledby="section-config">
+            <header class="page-section__head">
+                <b>01</b><span><h2 id="section-config">Gepinnte Konfiguration</h2><small>Das finale Design ist gesperrt.</small></span>
+            </header>
+            <dl class="field-grid field-grid--three">
+                <div><dt>Sprachmodell</dt><dd>{{ erhebung.modell_konfiguration.sprachmodell }}</dd></div>
+                <div><dt>Parameter</dt><dd>{{ erhebung.modell_konfiguration.parameter }}</dd></div>
+            </dl>
+        </section>
+
+        {% if erhebung.status == erhebung.Status.FINAL %}
+            <section class="page-section" aria-labelledby="section-stichproben">
+                <header class="page-section__head">
+                    <b>02</b><span><h2 id="section-stichproben">Stichproben</h2><small>Zeiträume für Teilnahmen verwalten.</small></span>
+                </header>
+                <div class="field-grid page-field--wide">
+                    <form method="post" action="{% url 'erhebungen:stichprobe_anlegen' erhebung.pk %}" style="margin-bottom: 2rem;">
+                        {% csrf_token %}
+                        <div style="display: flex; gap: 1rem; align-items: flex-end;">
+                            <div class="vignette-field">
+                                <label for="id_beginn">Beginn</label>
+                                <input id="id_beginn" type="datetime-local" name="beginn" required>
+                            </div>
+                            <div class="vignette-field">
+                                <label for="id_ende">Ende</label>
+                                <input id="id_ende" type="datetime-local" name="ende" required>
+                            </div>
+                            <button class="button" type="submit" style="margin-bottom: 0.5rem;">Stichprobe anlegen</button>
+                        </div>
+                    </form>
+
+                    <div class="table-wrap">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Zeitraum</th>
+                                    <th scope="col">Phase</th>
+                                    <th scope="col">Teilnahmen</th>
+                                    <th scope="col">Link</th>
+                                    <th scope="col">Aktion</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for stichprobe in stichproben %}
+                                    <tr>
+                                        <td>{{ stichprobe.beginn }} – {{ stichprobe.ende }}</td>
+                                        <td>{{ stichprobe.phase }}</td>
+                                        <td>{{ stichprobe.teilnahmezahl }}</td>
+                                        <td><input type="text" value="{{ stichprobe.teilnahme_url }}" readonly style="width: 100%;"></td>
+                                        <td>
+                                            {% if not stichprobe.archiviert and not stichprobe.traegt_daten %}
+                                                <form method="post" action="{% url 'erhebungen:stichprobe_archivieren' erhebung.pk stichprobe.pk %}">
+                                                    {% csrf_token %}
+                                                    <button class="button button--secondary button--small" type="submit">Archivieren</button>
+                                                </form>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% empty %}
+                                    <tr>
+                                        <td colspan="5" class="table__empty">Noch keine Stichproben angelegt.</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+        {% endif %}
+    {% endif %}
+
+    <div class="vignette-form-actions" style="margin-top: 2rem;">
+        <a class="button button--secondary" href="{% url 'erhebungen:liste' %}">Zu meinen Erhebungen</a>
     </div>
+</section>
 {% endblock %}

--- a/erhebungen/templates/erhebungen/detail.html
+++ b/erhebungen/templates/erhebungen/detail.html
@@ -6,6 +6,7 @@
 {% block extra_head %}
     <link rel="stylesheet" href="{% static 'css/vignette-form.css' %}">
     <link rel="stylesheet" href="{% static 'css/vignette-pages.css' %}">
+    {% if prototyp_variante %}<link rel="stylesheet" href="{% static 'css/prototyp-98.css' %}">{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -310,6 +311,8 @@
             </section>
         {% endif %}
     {% endif %}
+
+    {% if prototyp_variante %}{% include "erhebungen/prototyp_98_items.html" %}{% endif %}
 
     <div class="vignette-form-actions" style="margin-top: 2rem;">
         <a class="button button--secondary" href="{% url 'erhebungen:liste' %}">Zu meinen Erhebungen</a>

--- a/erhebungen/templates/erhebungen/liste.html
+++ b/erhebungen/templates/erhebungen/liste.html
@@ -1,41 +1,54 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}Meine Erhebungen{% endblock %}
 
+{% block extra_head %}
+    <link rel="stylesheet" href="{% static 'css/vignette-pages.css' %}">
+{% endblock %}
+
 {% block content %}
-    <div class="page area--research">
-        <header class="area-band"><h1>Meine Erhebungen</h1></header>
-        <section class="page-section">
-            <div class="page-section__head">
-                <b>01</b>
-                <div>
-                    <h2>Erhebungen</h2>
-                </div>
-            </div>
-            <div>
-                <p><a href="{% url 'erhebungen:anlegen' %}">Neue Erhebung anlegen</a></p>
-                <ul>
+<section class="page vignette-index-page">
+    <header class="page-head">
+        <div>
+            <p>Forschung</p>
+            <h1>Meine Erhebungen</h1>
+            <span>Daten für wissenschaftliche Analysen sammeln und verwalten.</span>
+        </div>
+        <a class="button" href="{% url 'erhebungen:anlegen' %}">Neue Erhebung anlegen</a>
+    </header>
+
+    {% if erhebungen %}
+        <div class="table-wrap vignette-index-table">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Zustand</th>
+                        <th scope="col">Aktion</th>
+                    </tr>
+                </thead>
+                <tbody>
                     {% for erhebung in erhebungen %}
-                        <li>
-                            <a href="{% url 'erhebungen:detail' erhebung.pk %}">
-                                {{ erhebung.name }}
-                            </a>
-                            <small>{{ erhebung.get_status_display }}</small>
-                            {% if erhebung.status == erhebung.Status.ENTWURF %}
-                                <form
-                                    method="post"
-                                    action="{% url 'erhebungen:loeschen' erhebung.pk %}"
-                                >
-                                    {% csrf_token %}
-                                    <button class="button button--danger" type="submit">Entwurf löschen</button>
-                                </form>
-                            {% endif %}
-                        </li>
-                    {% empty %}
-                        <li>Noch keine Erhebungen vorhanden.</li>
+                        <tr>
+                            <td>{{ erhebung.name }}</td>
+                            <td><span class="badge badge--{{ erhebung.status|lower }}">{{ erhebung.get_status_display }}</span></td>
+                            <td>
+                                <a class="button button--secondary" href="{% url 'erhebungen:detail' erhebung.pk %}">Öffnen</a>
+                                {% if erhebung.status == erhebung.Status.ENTWURF %}
+                                    <form method="post" action="{% url 'erhebungen:loeschen' erhebung.pk %}" style="display:inline-block; margin-left: 0.5rem;">
+                                        {% csrf_token %}
+                                        <button class="button button--danger" type="submit">Löschen</button>
+                                    </form>
+                                {% endif %}
+                            </td>
+                        </tr>
                     {% endfor %}
-                </ul>
-            </div>
-        </section>
-    </div>
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <p>Noch keine Erhebungen vorhanden.</p>
+    {% endif %}
+</section>
 {% endblock %}

--- a/erhebungen/templates/erhebungen/prototyp_98_items.html
+++ b/erhebungen/templates/erhebungen/prototyp_98_items.html
@@ -1,0 +1,360 @@
+{% comment %}
+PROTOTYP zu Issue #98 — WEGWERFCODE. Drei Varianten der Zuordnungs-UI
+(Fragebogen-Items an der Erhebung), umschaltbar über ?variant=A|B|C.
+Nichts wird gespeichert: alle Aktionen laufen clientseitig in Alpine auf
+Stub-Daten aus erhebungen/prototyp_98.py. Nach der Entscheidung: löschen.
+{% endcomment %}
+
+{{ prototyp_bibliothek|json_script:"prototyp-bibliothek" }}
+{{ prototyp_zugeordnet|json_script:"prototyp-zugeordnet" }}
+
+<div id="prototyp-98" x-data="{
+        gesperrt: false,
+        bibliothek: JSON.parse(document.getElementById('prototyp-bibliothek').textContent),
+        zugeordnet: JSON.parse(document.getElementById('prototyp-zugeordnet').textContent),
+        q: '',
+        gezogen: null,
+
+        get sichtbareBibliothek() {
+            const q = this.q.trim().toLowerCase();
+            return this.bibliothek.filter(i => !q || i.text.toLowerCase().includes(q));
+        },
+        liste(andockpunkt) {
+            return this.zugeordnet
+                .filter(i => i.andockpunkt === andockpunkt)
+                .sort((a, b) => a.position - b.position);
+        },
+        typLabel(typ) { return typ === 'likert' ? 'Likert' : 'Freitext'; },
+        aufnehmen(pk, andockpunkt) {
+            if (this.gesperrt) return;
+            const index = this.bibliothek.findIndex(i => i.pk === pk);
+            if (index === -1) return;
+            const item = this.bibliothek.splice(index, 1)[0];
+            this.zugeordnet.push({ ...item, andockpunkt, position: this.liste(andockpunkt).length + 1 });
+        },
+        entfernen(pk) {
+            if (this.gesperrt) return;
+            const index = this.zugeordnet.findIndex(i => i.pk === pk);
+            if (index === -1) return;
+            const item = this.zugeordnet.splice(index, 1)[0];
+            this.bibliothek.push({ pk: item.pk, text: item.text, typ: item.typ });
+            this.neuNummerieren(item.andockpunkt);
+        },
+        andockpunktSetzen(pk, andockpunkt) {
+            if (this.gesperrt) return;
+            const item = this.zugeordnet.find(i => i.pk === pk);
+            if (!item || item.andockpunkt === andockpunkt) return;
+            const alt = item.andockpunkt;
+            item.andockpunkt = andockpunkt;
+            item.position = this.liste(andockpunkt).length;
+            this.neuNummerieren(alt);
+            this.neuNummerieren(andockpunkt);
+        },
+        verschieben(pk, delta) {
+            if (this.gesperrt) return;
+            const item = this.zugeordnet.find(i => i.pk === pk);
+            const reihe = this.liste(item.andockpunkt);
+            const index = reihe.findIndex(i => i.pk === pk);
+            const ziel = index + delta;
+            if (ziel < 0 || ziel >= reihe.length) return;
+            [reihe[index].position, reihe[ziel].position] = [reihe[ziel].position, reihe[index].position];
+        },
+        positionSetzen(pk, position) {
+            if (this.gesperrt) return;
+            const item = this.zugeordnet.find(i => i.pk === pk);
+            const reihe = this.liste(item.andockpunkt).filter(i => i.pk !== pk);
+            reihe.splice(Number(position) - 1, 0, item);
+            reihe.forEach((i, n) => i.position = n + 1);
+        },
+        neuNummerieren(andockpunkt) {
+            this.liste(andockpunkt).forEach((i, n) => i.position = n + 1);
+        },
+        ablegen(andockpunkt, zielPk) {
+            if (this.gesperrt || this.gezogen === null) return;
+            const pk = this.gezogen;
+            this.gezogen = null;
+            if (this.bibliothek.some(i => i.pk === pk)) this.aufnehmen(pk, andockpunkt);
+            else this.andockpunktSetzen(pk, andockpunkt);
+            if (zielPk !== null && zielPk !== pk) {
+                const ziel = this.zugeordnet.find(i => i.pk === zielPk);
+                if (ziel && ziel.andockpunkt === andockpunkt) this.positionSetzen(pk, ziel.position);
+            }
+        }
+    }"
+>
+
+    <div class="prototyp-chrome">
+        <strong>Prototyp #98</strong> — Variante {{ prototyp_variante }}: {{ prototyp_variantenname }}.
+        Stub-Daten, nichts wird gespeichert.
+        <label style="margin-left: 1rem;">
+            <input type="checkbox" x-model="gesperrt"> Ansicht: finalisiert (gesperrt)
+        </label>
+    </div>
+
+{% if prototyp_variante == "A" %}
+    {% comment %} A — Zwei Andockpunkt-Bereiche: die Vignettenauswahl zweimal, je Andockpunkt einer. {% endcomment %}
+    <template x-for="bereich in [
+            { schluessel: 'nach_sitzung', nummer: '04', titel: 'Items nach jeder Vignettensitzung', hinweis: 'Diese Items werden nach jeder einzelnen Sitzung vorgelegt.' },
+            { schluessel: 'am_ende', nummer: '05', titel: 'Items am Ende', hinweis: 'Diese Items werden einmal nach allen Sitzungen vorgelegt.' }
+        ]" :key="bereich.schluessel">
+        <section class="page-section">
+            <header class="page-section__head">
+                <b x-text="bereich.nummer"></b>
+                <span>
+                    <h2 x-text="bereich.titel"></h2>
+                    <small x-text="bereich.hinweis"></small>
+                </span>
+            </header>
+
+            <p class="prototyp-frost" x-show="!gesperrt">
+                Mit dem Finalisieren friert diese Batterie ein und ist danach nicht mehr änderbar.
+            </p>
+
+            <div class="field-grid page-field--wide" style="grid-template-columns: 1fr 1fr; align-items: start;">
+                <div class="vignette-field" x-show="!gesperrt">
+                    <p><strong>Bibliothek</strong></p>
+                    <div class="table-toolbar">
+                        <input type="search" class="table-toolbar__search" placeholder="Suchen…" x-model="q">
+                    </div>
+                    <div class="table-wrap vignette-index-table">
+                        <table class="table">
+                            <thead><tr><th scope="col">Item</th><th scope="col">Typ</th><th scope="col">Aktion</th></tr></thead>
+                            <tbody>
+                                <template x-for="item in sichtbareBibliothek" :key="item.pk">
+                                    <tr>
+                                        <td x-text="item.text"></td>
+                                        <td><span class="badge" x-text="typLabel(item.typ)"></span></td>
+                                        <td><button class="button button--secondary button--small" type="button" @click="aufnehmen(item.pk, bereich.schluessel)">Aufnehmen</button></td>
+                                    </tr>
+                                </template>
+                                <tr x-show="sichtbareBibliothek.length === 0">
+                                    <td colspan="3" class="table__empty">Keine weiteren Items verfügbar.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+
+                <div class="vignette-field" :style="gesperrt ? 'grid-column: 1 / -1' : ''">
+                    <p><strong>Aufgenommen</strong></p>
+                    <div class="table-wrap vignette-index-table">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Nr.</th><th scope="col">Item</th><th scope="col">Typ</th>
+                                    <th scope="col" x-show="!gesperrt">Reihenfolge</th>
+                                    <th scope="col" x-show="!gesperrt">Aktion</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <template x-for="(item, n) in liste(bereich.schluessel)" :key="item.pk">
+                                    <tr>
+                                        <td x-text="n + 1"></td>
+                                        <td x-text="item.text"></td>
+                                        <td><span class="badge" x-text="typLabel(item.typ)"></span></td>
+                                        <td x-show="!gesperrt">
+                                            <button class="button button--secondary button--small" type="button" @click="verschieben(item.pk, -1)" :disabled="n === 0">↑</button>
+                                            <button class="button button--secondary button--small" type="button" @click="verschieben(item.pk, 1)" :disabled="n === liste(bereich.schluessel).length - 1">↓</button>
+                                        </td>
+                                        <td x-show="!gesperrt">
+                                            <button class="button button--danger button--small" type="button" @click="entfernen(item.pk)">Entfernen</button>
+                                        </td>
+                                    </tr>
+                                </template>
+                                <tr x-show="liste(bereich.schluessel).length === 0">
+                                    <td colspan="5" class="table__empty">Keine Items zugeordnet.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </template>
+{% endif %}
+
+{% if prototyp_variante == "B" %}
+    {% comment %} B — Eine Bibliothek links, zwei Körbe rechts; Zuordnung und Reihenfolge per Drag & Drop. {% endcomment %}
+    <section class="page-section">
+        <header class="page-section__head">
+            <b>04</b>
+            <span>
+                <h2>Fragebogen-Items</h2>
+                <small>Ziehen Sie Items aus der Bibliothek in einen Andockpunkt; die Reihenfolge im Korb ergibt die Vorlagereihenfolge.</small>
+            </span>
+        </header>
+
+        <p class="prototyp-frost" x-show="!gesperrt">
+            Mit dem Finalisieren frieren beide Körbe ein und sind danach nicht mehr änderbar.
+        </p>
+
+        <div class="field-grid page-field--wide" style="grid-template-columns: 1fr 1.2fr; align-items: start;" :style="gesperrt ? 'grid-template-columns: 1fr' : ''">
+            <div class="vignette-field" x-show="!gesperrt">
+                <p><strong>Bibliothek</strong></p>
+                <div class="table-toolbar">
+                    <input type="search" class="table-toolbar__search" placeholder="Suchen…" x-model="q">
+                </div>
+                <ul class="prototyp-korb prototyp-korb--quelle">
+                    <template x-for="item in sichtbareBibliothek" :key="item.pk">
+                        <li class="prototyp-karte" draggable="true" @dragstart="gezogen = item.pk">
+                            <span class="prototyp-karte__griff">⠿</span>
+                            <span class="prototyp-karte__text">
+                                <span x-text="item.text"></span>
+                                <span class="badge" x-text="typLabel(item.typ)"></span>
+                            </span>
+                        </li>
+                    </template>
+                    <li class="prototyp-leer" x-show="sichtbareBibliothek.length === 0">Keine weiteren Items.</li>
+                </ul>
+            </div>
+
+            <div class="vignette-field">
+                <template x-for="korb in [
+                        { schluessel: 'nach_sitzung', titel: 'Nach jeder Vignettensitzung', hinweis: 'wiederholt sich je Sitzung' },
+                        { schluessel: 'am_ende', titel: 'Am Ende', hinweis: 'einmal nach allen Sitzungen' }
+                    ]" :key="korb.schluessel">
+                    <div class="prototyp-andockpunkt">
+                        <p>
+                            <strong x-text="korb.titel"></strong>
+                            <small x-text="' — ' + korb.hinweis"></small>
+                        </p>
+                        <ul class="prototyp-korb prototyp-korb--ziel" :class="gesperrt && 'prototyp-korb--gesperrt'"
+                            @dragover.prevent @drop.prevent="ablegen(korb.schluessel, null)">
+                            <template x-for="(item, n) in liste(korb.schluessel)" :key="item.pk">
+                                <li class="prototyp-karte" :draggable="!gesperrt"
+                                    @dragstart="gezogen = item.pk"
+                                    @dragover.prevent @drop.prevent.stop="ablegen(korb.schluessel, item.pk)">
+                                    <span class="prototyp-karte__griff" x-show="!gesperrt">⠿</span>
+                                    <span class="prototyp-karte__nummer" x-text="n + 1"></span>
+                                    <span class="prototyp-karte__text">
+                                        <span x-text="item.text"></span>
+                                        <span class="badge" x-text="typLabel(item.typ)"></span>
+                                    </span>
+                                    <button class="button button--danger button--small" type="button" x-show="!gesperrt" @click="entfernen(item.pk)">×</button>
+                                </li>
+                            </template>
+                            <li class="prototyp-leer" x-show="liste(korb.schluessel).length === 0">
+                                <span x-text="gesperrt ? 'Keine Items.' : 'Items hierher ziehen.'"></span>
+                            </li>
+                        </ul>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </section>
+{% endif %}
+
+{% if prototyp_variante == "C" %}
+    {% comment %} C — Eine Zuordnungstabelle: Andockpunkt und Position als Feld je Zeile (nah an der Vignetten-Prior-Art). {% endcomment %}
+    <section class="page-section">
+        <header class="page-section__head">
+            <b>04</b>
+            <span>
+                <h2>Fragebogen-Items</h2>
+                <small>Nehmen Sie Items auf und setzen Sie je Zeile Andockpunkt und Position.</small>
+            </span>
+        </header>
+
+        <div class="field-grid page-field--wide" style="grid-template-columns: 1fr 1.4fr; align-items: start;" :style="gesperrt ? 'grid-template-columns: 1fr' : ''">
+            <div class="vignette-field" x-show="!gesperrt">
+                <p><strong>Bibliothek</strong></p>
+                <div class="table-toolbar">
+                    <input type="search" class="table-toolbar__search" placeholder="Suchen…" x-model="q">
+                    <span class="table-toolbar__count" x-text="sichtbareBibliothek.length + ' von ' + bibliothek.length"></span>
+                </div>
+                <div class="table-wrap vignette-index-table">
+                    <table class="table">
+                        <thead><tr><th scope="col">Item</th><th scope="col">Aktion</th></tr></thead>
+                        <tbody>
+                            <template x-for="item in sichtbareBibliothek" :key="item.pk">
+                                <tr>
+                                    <td>
+                                        <span x-text="item.text"></span>
+                                        <span class="badge" x-text="typLabel(item.typ)"></span>
+                                    </td>
+                                    <td><button class="button button--secondary button--small" type="button" @click="aufnehmen(item.pk, 'nach_sitzung')">Aufnehmen</button></td>
+                                </tr>
+                            </template>
+                            <tr x-show="sichtbareBibliothek.length === 0">
+                                <td colspan="2" class="table__empty">Keine weiteren Items verfügbar.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="vignette-field">
+                <p><strong>Zugeordnete Items</strong></p>
+                <p class="prototyp-frost" x-show="!gesperrt">
+                    Mit dem Finalisieren friert diese Tabelle ein und ist danach nicht mehr änderbar.
+                </p>
+                <div class="table-wrap vignette-index-table">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Item</th>
+                                <th scope="col">Andockpunkt</th>
+                                <th scope="col">Position</th>
+                                <th scope="col" x-show="!gesperrt">Aktion</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="andockpunkt in ['nach_sitzung', 'am_ende']" :key="andockpunkt">
+                                <template x-for="item in liste(andockpunkt)" :key="item.pk">
+                                    <tr>
+                                        <td>
+                                            <span x-text="item.text"></span>
+                                            <span class="badge" x-text="typLabel(item.typ)"></span>
+                                        </td>
+                                        <td>
+                                            <select x-show="!gesperrt" :value="item.andockpunkt" @change="andockpunktSetzen(item.pk, $event.target.value)">
+                                                <option value="nach_sitzung">nach jeder Vignettensitzung</option>
+                                                <option value="am_ende">am Ende</option>
+                                            </select>
+                                            <span x-show="gesperrt" x-text="item.andockpunkt === 'nach_sitzung' ? 'nach jeder Vignettensitzung' : 'am Ende'"></span>
+                                        </td>
+                                        <td>
+                                            <select x-show="!gesperrt" :value="item.position" @change="positionSetzen(item.pk, $event.target.value)">
+                                                <template x-for="n in liste(item.andockpunkt).length" :key="n">
+                                                    <option :value="n" x-text="n"></option>
+                                                </template>
+                                            </select>
+                                            <span x-show="gesperrt" x-text="item.position"></span>
+                                        </td>
+                                        <td x-show="!gesperrt">
+                                            <button class="button button--danger button--small" type="button" @click="entfernen(item.pk)">Entfernen</button>
+                                        </td>
+                                    </tr>
+                                </template>
+                            </template>
+                            <tr x-show="zugeordnet.length === 0">
+                                <td colspan="4" class="table__empty">Noch keine Items zugeordnet.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endif %}
+</div>
+
+{% comment %} Wegwerf-Switcher: fixierte Leiste, ←/→ blättern durch die Varianten. {% endcomment %}
+<div class="prototyp-switcher" x-data="{
+        varianten: {{ prototyp_varianten|safe }},
+        aktuell: '{{ prototyp_variante }}',
+        blaettern(delta) {
+            const index = this.varianten.indexOf(this.aktuell);
+            const ziel = this.varianten[(index + delta + this.varianten.length) % this.varianten.length];
+            const url = new URL(window.location);
+            url.searchParams.set('variant', ziel);
+            window.location = url;
+        }
+    }"
+    @keydown.arrow-left.window="if (!['INPUT','TEXTAREA','SELECT'].includes(document.activeElement.tagName)) blaettern(-1)"
+    @keydown.arrow-right.window="if (!['INPUT','TEXTAREA','SELECT'].includes(document.activeElement.tagName)) blaettern(1)"
+>
+    <button type="button" @click="blaettern(-1)" aria-label="Vorige Variante">←</button>
+    <span>{{ prototyp_variante }} — {{ prototyp_variantenname }}</span>
+    <button type="button" @click="blaettern(1)" aria-label="Nächste Variante">→</button>
+</div>

--- a/erhebungen/views.py
+++ b/erhebungen/views.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import Callable, Concatenate, ParamSpec
 from uuid import UUID
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -23,6 +24,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from .ablauf import naechster_schritt
+from .prototyp_98 import kontext as prototyp_98_kontext
 from .models import (
     Erhebung,
     Erhebungsbindung,
@@ -170,6 +172,12 @@ def detail(request: HttpRequest, pk: int) -> HttpResponse:
             "kann_archivieren": erhebung.kann_archiviert_werden,
             "kann_entarchivieren": erhebung.kann_entarchiviert_werden,
             "stichproben": stichproben,
+            # PROTOTYP #98 — mit prototyp_98.py und dem Template wieder entfernen.
+            **(
+                prototyp_98_kontext(request.GET.get("variant"))
+                if settings.DEBUG
+                else {}
+            ),
         },
     )
 

--- a/erhebungen/views.py
+++ b/erhebungen/views.py
@@ -130,17 +130,42 @@ def detail(request: HttpRequest, pk: int) -> HttpResponse:
         stichprobe.teilnahme_url = request.build_absolute_uri(
             reverse("erhebungen:teilnehmen", args=[stichprobe.teilnahme_link])
         )
+        
+    vignettenzugehoerigkeiten = erhebung.vignettenzugehoerigkeiten.select_related(
+        "vignette", "vignette__historie"
+    )
+    aufgenommene = []
+    for z in vignettenzugehoerigkeiten:
+        aufgenommene.append({
+            "pk": z.vignette.pk,
+            "label": z.vignette.historie.name or z.vignette.fach,
+            "fach": z.vignette.fach,
+            "thema": z.vignette.thema,
+            "entfernen_url": reverse("erhebungen:vignette_entfernen", args=[erhebung.pk, z.vignette.pk]),
+        })
+
+    verfuegbare_vignetten = _eigene_finalen_vignetten(request).exclude(
+        pk__in=erhebung.vignetten.values("pk")
+    )
+    verfuegbare = []
+    for v in verfuegbare_vignetten:
+        verfuegbare.append({
+            "pk": v.pk,
+            "label": v.historie.name or v.fach,
+            "fach": v.fach,
+            "thema": v.thema,
+            "aufnehmen_url": reverse("erhebungen:vignette_hinzufuegen", args=[erhebung.pk, v.pk]),
+        })
+
     return render(
         request,
         "erhebungen/detail.html",
         {
             "erhebung": erhebung,
-            "vignettenzugehoerigkeiten": erhebung.vignettenzugehoerigkeiten.select_related(
-                "vignette", "vignette__historie"
-            ),
-            "verfuegbare_vignetten": _eigene_finalen_vignetten(request).exclude(
-                pk__in=erhebung.vignetten.values("pk")
-            ),
+            "vignettenzugehoerigkeiten": vignettenzugehoerigkeiten,
+            "aufgenommene_daten": aufgenommene,
+            "verfuegbare_daten": verfuegbare,
+            "verfuegbare_vignetten": verfuegbare_vignetten,
             "kann_zurueckziehen": erhebung.kann_zurueckgezogen_werden,
             "kann_archivieren": erhebung.kann_archiviert_werden,
             "kann_entarchivieren": erhebung.kann_entarchiviert_werden,

--- a/konten/navigation.py
+++ b/konten/navigation.py
@@ -66,7 +66,7 @@ def navigation(request: HttpRequest) -> dict[str, bool]:
         "zeige_entwicklung": ist_administratorin or AUTORIN_GRUPPE in rollen,
         "zeige_ausbildung_kuratieren": ist_administratorin
         or AUSBILDERIN_GRUPPE in rollen,
-        "zeige_teilnahme": ist_administratorin or not rollen,
+        "zeige_teilnahme": not rollen,
         "zeige_forschung": ist_administratorin or FORSCHENDE_GRUPPE in rollen,
         "zeige_system": ist_administratorin,
         "simulationskern_verwalten": ist_administratorin,

--- a/konten/tests/test_navigation.py
+++ b/konten/tests/test_navigation.py
@@ -65,7 +65,7 @@ from konten.models import Konto
             {
                 "zeige_entwicklung": True,
                 "zeige_ausbildung_kuratieren": True,
-                "zeige_teilnahme": True,
+                "zeige_teilnahme": False,
                 "zeige_forschung": True,
                 "zeige_system": True,
                 "simulationskern_verwalten": True,
@@ -131,16 +131,18 @@ class SidebarNavigationTests(TestCase):
         self.assertIn("Meine Erhebungen", sidebar)
         self.assertIn("Neue Erhebung anlegen", sidebar)
 
-    def test_administratorin_sieht_alle_bereiche(self) -> None:
-        """Die Gruppenrolle der Administration überschreibt alle Sichtbarkeiten."""
+    def test_administratorin_sieht_alle_bereiche_ausser_teilnahme(self) -> None:
+        """Die Gruppenrolle der Administration überschreibt fast alle Sichtbarkeiten."""
         sidebar: str = self._sidebar_fuer("Administrator:in")
 
         for text in (
             "Vignetten ansehen",
             "Simulationskern verwalten",
             "Trainingskatalog erstellen",
-            "Training starten",
             "Meine Erhebungen",
             "Administration",
         ):
             self.assertIn(text, sidebar)
+
+        self.assertNotIn("Training starten", sidebar)
+        self.assertNotIn("Meine Trainings", sidebar)

--- a/static/css/prototyp-98.css
+++ b/static/css/prototyp-98.css
@@ -1,0 +1,115 @@
+/* PROTOTYP zu Issue #98 — WEGWERFCODE. Nach der Entscheidung löschen. */
+
+.prototyp-chrome {
+    margin: var(--space-5) 0 var(--space-3);
+    padding: var(--space-3);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface-muted);
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}
+
+.prototyp-frost {
+    margin-bottom: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-left: 3px solid var(--color-area-research-solid);
+    background: var(--color-area-research-tint);
+    font-size: 0.875rem;
+}
+
+.prototyp-korb {
+    list-style: none;
+    margin: 0;
+    padding: var(--space-2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface);
+    min-height: 6rem;
+}
+
+.prototyp-korb--ziel {
+    border-style: dashed;
+    background: var(--color-area-research-tint);
+}
+
+.prototyp-korb--gesperrt {
+    border-style: solid;
+    background: var(--color-surface-muted);
+}
+
+.prototyp-andockpunkt {
+    margin-bottom: var(--space-4);
+}
+
+.prototyp-karte {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    background: var(--color-surface);
+}
+
+.prototyp-karte[draggable="true"] {
+    cursor: grab;
+}
+
+.prototyp-karte__griff {
+    color: var(--color-text-muted);
+}
+
+.prototyp-karte__nummer {
+    display: inline-grid;
+    place-items: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--color-area-research-solid);
+    color: var(--color-area-research-on-solid);
+    font-size: 0.75rem;
+}
+
+.prototyp-karte__text {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.prototyp-leer {
+    padding: var(--space-3);
+    color: var(--color-text-muted);
+    text-align: center;
+    font-size: 0.875rem;
+}
+
+.prototyp-switcher {
+    position: fixed;
+    bottom: var(--space-4);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-4);
+    border-radius: 999px;
+    background: var(--phsg-gray-900);
+    color: var(--phsg-white);
+    box-shadow: 0 4px 16px rgb(0 0 0 / 0.3);
+    font-size: 0.875rem;
+}
+
+.prototyp-switcher button {
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+}

--- a/static/css/tokens.css
+++ b/static/css/tokens.css
@@ -7,103 +7,109 @@
    nur als Quelle für die semantischen Tokens. Vorerst nur Light Mode. */
 
 :root {
-    /* ---- Primitive: Primärfarben (Logofarben, verbindlich) ---- */
-    --phsg-bright-green: #1fc070;
-    --phsg-deep-mint: #1c3e37;
+   /* ---- Primitive: Primärfarben (Logofarben, verbindlich) ---- */
+   --phsg-bright-green: #1fc070;
+   --phsg-deep-mint: #1c3e37;
 
-    /* ---- Primitive: Graustufen (für digitale Anwendungen) ---- */
-    --phsg-white: #ffffff;
-    --phsg-gray-050: #f5f7f6;
-    --phsg-gray-100: #ececec;
-    --phsg-gray-200: #d8dad9;
-    --phsg-gray-300: #c5c7c6;
-    --phsg-gray-400: #b2b4b3;
-    --phsg-gray-500: #9d9f9e;
-    --phsg-gray-600: #878988;
-    --phsg-gray-700: #6f7170;
-    --phsg-gray-800: #555756;
-    --phsg-gray-900: #383836;
-    --phsg-black: #000000;
+   /* ---- Primitive: Graustufen (für digitale Anwendungen) ---- */
+   --phsg-white: #ffffff;
+   --phsg-gray-050: #f5f7f6;
+   --phsg-gray-100: #ececec;
+   --phsg-gray-200: #d8dad9;
+   --phsg-gray-300: #c5c7c6;
+   --phsg-gray-400: #b2b4b3;
+   --phsg-gray-500: #9d9f9e;
+   --phsg-gray-600: #878988;
+   --phsg-gray-700: #6f7170;
+   --phsg-gray-800: #555756;
+   --phsg-gray-900: #383836;
+   --phsg-black: #000000;
 
-    /* ---- Primitive: Sekundärpalette (Light / Bright / Dark / Deep) ----
+   /* ---- Primitive: Sekundärpalette (Light / Bright / Dark / Deep) ----
        Quelle für die semantischen Bereichs- und Rückmeldungsfarben. */
-    --phsg-green-light: #d8ecd8;
-    --phsg-green-bright: #1fc070;
-    --phsg-green-dark: #009b56;
-    --phsg-green-deep: #2c512c;
-    --phsg-mint-light: #c7e6e2;
-    --phsg-mint-bright: #56ba9d;
-    --phsg-mint-dark: #00836a;
-    --phsg-mint-deep: #1c3e37;
-    --phsg-blue-light: #dcf1fc;
-    --phsg-blue-bright: #50bacd;
-    --phsg-blue-dark: #005d75;
-    --phsg-blue-deep: #1e2c39;
-    --phsg-red-light: #fbddde;
-    --phsg-red-bright: #ee7e7e;
-    --phsg-red-dark: #bf4850;
-    --phsg-red-deep: #651819;
-    --phsg-purple-light: #e5d3e7;
-    --phsg-purple-bright: #b982b6;
-    --phsg-purple-dark: #7b2d61;
-    --phsg-purple-deep: #422335;
-    --phsg-yellow-light: #fefbd3;
-    --phsg-yellow-bright: #c8d73b;
-    --phsg-yellow-dark: #967231;
-    --phsg-yellow-deep: #3d301a;
+   --phsg-green-light: #d8ecd8;
+   --phsg-green-bright: #1fc070;
+   --phsg-green-dark: #009b56;
+   --phsg-green-deep: #2c512c;
+   --phsg-mint-light: #c7e6e2;
+   --phsg-mint-bright: #56ba9d;
+   --phsg-mint-dark: #00836a;
+   --phsg-mint-deep: #1c3e37;
+   --phsg-blue-light: #dcf1fc;
+   --phsg-blue-bright: #50bacd;
+   --phsg-blue-dark: #005d75;
+   --phsg-blue-deep: #1e2c39;
+   --phsg-red-light: #fbddde;
+   --phsg-red-bright: #ee7e7e;
+   --phsg-red-dark: #bf4850;
+   --phsg-red-deep: #651819;
+   --phsg-purple-light: #e5d3e7;
+   --phsg-purple-bright: #b982b6;
+   --phsg-purple-dark: #7b2d61;
+   --phsg-purple-deep: #422335;
+   --phsg-yellow-light: #fefbd3;
+   --phsg-yellow-bright: #c8d73b;
+   --phsg-yellow-dark: #967231;
+   --phsg-yellow-deep: #3d301a;
 
-    /* ---- Semantisch: Farben nach Rolle ---- */
-    --color-text: var(--phsg-gray-900);        /* primärer Lesetext */
-    --color-text-muted: var(--phsg-gray-700);  /* sekundär, ADR-0023 Option A */
-    --color-text-on-accent: var(--phsg-white); /* Text auf Farbflächen: weiss */
+   /* ---- Semantisch: Farben nach Rolle ---- */
+   --color-text: var(--phsg-gray-900);
+   /* primärer Lesetext */
+   --color-text-muted: var(--phsg-gray-700);
+   /* sekundär, ADR-0023 Option A */
+   --color-text-on-accent: var(--phsg-white);
+   /* Text auf Farbflächen: weiss */
 
-    --color-accent: var(--phsg-green-dark);      /* Links, Buttons, aktive Nav */
-    --color-accent-hover: var(--phsg-green-deep);/* Hover/aktiv */
-    --color-focus: var(--phsg-bright-green);     /* Fokus-Ring, Highlights */
+   --color-accent: var(--phsg-green-dark);
+   /* Links, Buttons, aktive Nav */
+   --color-accent-hover: var(--phsg-green-deep);
+   /* Hover/aktiv */
+   --color-focus: var(--phsg-bright-green);
+   /* Fokus-Ring, Highlights */
 
-    --color-surface: var(--phsg-white);
-    --color-surface-muted: var(--phsg-gray-050);
-    --color-border: var(--phsg-gray-200);
+   --color-surface: var(--phsg-white);
+   --color-surface-muted: var(--phsg-gray-050);
+   --color-border: var(--phsg-gray-200);
 
-    --color-footer-bg: var(--phsg-deep-mint);
-    --color-footer-text: var(--phsg-white);
+   --color-footer-bg: var(--phsg-deep-mint);
+   --color-footer-text: var(--phsg-white);
 
-    /* ---- Semantisch: Bereichs- und Gefahrfarben (ADR-0024) ---- */
-    --color-area-participant-solid: var(--phsg-mint-dark);
-    --color-area-participant-on-solid: var(--phsg-white);
-    --color-area-participant-tint: var(--phsg-green-light);
-    --color-area-authoring-solid: var(--phsg-yellow-light);
-    --color-area-authoring-on-solid: var(--phsg-yellow-deep);
-    --color-area-authoring-tint: var(--phsg-yellow-light);
-    --color-area-research-solid: var(--phsg-purple-dark);
-    --color-area-research-on-solid: var(--phsg-white);
-    --color-area-research-tint: var(--phsg-purple-light);
-    --color-area-system-solid: var(--phsg-blue-dark);
-    --color-area-system-on-solid: var(--phsg-white);
-    --color-area-system-tint: var(--phsg-blue-light);
-    --color-danger: var(--phsg-red-dark);
-    --color-danger-tint: var(--phsg-red-light);
-    --color-danger-emphasis: var(--phsg-red-deep);
+   /* ---- Semantisch: Bereichs- und Gefahrfarben (ADR-0024) ---- */
+   --color-area-participant-solid: var(--phsg-mint-dark);
+   --color-area-participant-on-solid: var(--phsg-white);
+   --color-area-participant-tint: var(--phsg-green-light);
+   --color-area-authoring-solid: var(--phsg-yellow-dark);
+   --color-area-authoring-on-solid: var(--phsg-white);
+   --color-area-authoring-tint: var(--phsg-yellow-light);
+   --color-area-research-solid: var(--phsg-purple-dark);
+   --color-area-research-on-solid: var(--phsg-white);
+   --color-area-research-tint: var(--phsg-purple-light);
+   --color-area-system-solid: var(--phsg-blue-dark);
+   --color-area-system-on-solid: var(--phsg-white);
+   --color-area-system-tint: var(--phsg-blue-light);
+   --color-danger: var(--phsg-red-dark);
+   --color-danger-tint: var(--phsg-red-light);
+   --color-danger-emphasis: var(--phsg-red-deep);
 
-    /* ---- Semantisch: Status- und Rückmeldungsfarben ---- */
-    --color-success: var(--phsg-green-dark);
-    --color-info: var(--phsg-blue-dark);
+   /* ---- Semantisch: Status- und Rückmeldungsfarben ---- */
+   --color-success: var(--phsg-green-dark);
+   --color-info: var(--phsg-blue-dark);
 
-    /* ---- Typografie ---- */
-    --font-heading: "Platypi", Georgia, serif;
-    --font-body: "Albert Sans", system-ui, sans-serif;
+   /* ---- Typografie ---- */
+   --font-heading: "Platypi", Georgia, serif;
+   --font-body: "Albert Sans", system-ui, sans-serif;
 
-    /* ---- Spacing: 8-px-Abstandsraster ---- */
-    --space-1: 8px;
-    --space-2: 16px;
-    --space-3: 24px;
-    --space-4: 32px;
-    --space-5: 40px;
-    --space-6: 48px;
-    --space-7: 56px;
-    --space-8: 64px;
+   /* ---- Spacing: 8-px-Abstandsraster ---- */
+   --space-1: 8px;
+   --space-2: 16px;
+   --space-3: 24px;
+   --space-4: 32px;
+   --space-5: 40px;
+   --space-6: 48px;
+   --space-7: 56px;
+   --space-8: 64px;
 
-    /* ---- Layout ---- */
-    --content-max-width: 1440px;
-    --radius: 8px;
+   /* ---- Layout ---- */
+   --content-max-width: 1440px;
+   --radius: 8px;
 }


### PR DESCRIPTION
Wegwerf-Prototyp zu #98 — **nicht zum Mergen**, nur zum Anschauen und Entscheiden.

## Anschauen

```
git checkout worktree-wayfinder-98-zuordnungs-ui
DEBUG=True uv run python manage.py runserver
```

Dann eine Erhebung im Entwurf öffnen und `?variant=A` anhängen:
`/erhebungen/eigene/<pk>/?variant=A` — mit ←/→ oder der Leiste unten durchblättern.
Ohne `?variant=` ist der Prototyp aus.

Jede Variante hat oben einen Umschalter **„Ansicht: finalisiert (gesperrt)"**, der die eingefrorene Ansicht derselben Variante zeigt.

## Die drei Varianten

| | Struktur | Andockpunkt | Reihenfolge |
|---|---|---|---|
| **A** | Zwei getrennte Bereiche, je Andockpunkt eine Bibliothek/Ziel-Spalte | ergibt sich aus dem Bereich | Hoch/Runter-Knöpfe |
| **B** | Eine Bibliothek links, zwei Körbe rechts | Korb, in den man zieht | Drag & Drop im Korb |
| **C** | Eine Bibliothek links, eine Zuordnungstabelle rechts | Select je Zeile | Select je Zeile |

Variante C liegt am nächsten an der Vignettenauswahl (#72), die Positionen ebenfalls über Selects setzt.

## Hinweise

- Der erste Commit übernimmt den **uncommitteten Arbeitsstand** aus dem Checkout (Umbau der Erhebungs-Detailseite), damit der Prototyp neben der aktuellen Seite steht. Nicht mergen.
- Die App `fragebogen_items` gibt es noch nicht (#97), also Stub-Items aus `erhebungen/prototyp_98.py`. Nichts wird persistiert, alle Aktionen laufen clientseitig in Alpine.
- Zwei Tests in `erhebungen.tests.test_forschenden_views` schlagen fehl — **schon auf dem Basis-Commit ohne den Prototyp**, sie hängen am Template-Umbau (`<dt>Phase</dt>` ist jetzt eine Tabelle, das `selected` beim Randomisierungs-Select macht jetzt Alpine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)