### PR TITLE
Teilnahme-Links auf Konten ohne Rolle beschränken

### DIFF
--- a/konten/navigation.py
+++ b/konten/navigation.py
@@ -66,7 +66,7 @@ def navigation(request: HttpRequest) -> dict[str, bool]:
         "zeige_entwicklung": ist_administratorin or AUTORIN_GRUPPE in rollen,
         "zeige_ausbildung_kuratieren": ist_administratorin
         or AUSBILDERIN_GRUPPE in rollen,
-        "zeige_teilnahme": ist_administratorin or not rollen,
+        "zeige_teilnahme": not rollen,
         "zeige_forschung": ist_administratorin or FORSCHENDE_GRUPPE in rollen,
         "zeige_system": ist_administratorin,
         "simulationskern_verwalten": ist_administratorin,

--- a/konten/tests/test_navigation.py
+++ b/konten/tests/test_navigation.py
@@ -65,7 +65,7 @@ from konten.models import Konto
             {
                 "zeige_entwicklung": True,
                 "zeige_ausbildung_kuratieren": True,
-                "zeige_teilnahme": True,
+                "zeige_teilnahme": False,
                 "zeige_forschung": True,
                 "zeige_system": True,
                 "simulationskern_verwalten": True,
@@ -131,16 +131,18 @@ class SidebarNavigationTests(TestCase):
         self.assertIn("Meine Erhebungen", sidebar)
         self.assertIn("Neue Erhebung anlegen", sidebar)
 
-    def test_administratorin_sieht_alle_bereiche(self) -> None:
-        """Die Gruppenrolle der Administration überschreibt alle Sichtbarkeiten."""
+    def test_administratorin_sieht_alle_bereiche_ausser_teilnahme(self) -> None:
+        """Die Gruppenrolle der Administration überschreibt fast alle Sichtbarkeiten."""
         sidebar: str = self._sidebar_fuer("Administrator:in")
 
         for text in (
             "Vignetten ansehen",
             "Simulationskern verwalten",
             "Trainingskatalog erstellen",
-            "Training starten",
             "Meine Erhebungen",
             "Administration",
         ):
             self.assertIn(text, sidebar)
+
+        self.assertNotIn("Training starten", sidebar)
+        self.assertNotIn("Meine Trainings", sidebar)


### PR DESCRIPTION
## Kontext

Nachzügler zu Spec #91 / Ticket #94. Die Rollen-Navigation ist umgesetzt und auf `main`; diese Änderung korrigiert eine Sichtbarkeitsregel.

## Änderung

`zeige_teilnahme` in `konten/navigation.py` hängt nicht mehr am Admin-Override:

```diff
-"zeige_teilnahme": ist_administratorin or not rollen,
+"zeige_teilnahme": not rollen,
```

Damit sehen Administrator:innen „Training starten" und „Meine Trainings" nicht mehr. Begründung ist dieselbe wie bei der reinen Ausbilder:in-Rolle: für die Erprobung eines Trainings gibt es den Probelauf (ADR-0014).

`zeige_teilnahme` ist damit die einzige Sichtbarkeit, für die „Administrator:in sieht überall alles" bewusst **nicht** gilt.

## Tests

`konten/tests/test_navigation.py` angepasst; `python manage.py test konten.tests.test_navigation` → 5/5 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)